### PR TITLE
[Fix] Firebase_url 모듈 로직 수정 #49

### DIFF
--- a/src/modules/Hardcoded.py
+++ b/src/modules/Hardcoded.py
@@ -55,7 +55,10 @@ class HardCodedAnalyzer:
             data = "Firebase access Enable"
             print(data)
         elif res.status_code == 423:
-            data = "Firebase access disable"
+            data = "Firebase access Disable"
+            print(data)
+        elif res.status_code == 403:
+            data = "Firebase access Permission Denied"
             print(data)
         else:
             data = "Firebase access Error"
@@ -75,6 +78,7 @@ class HardCodedAnalyzer:
                     HardCoded_results.append(firebase_res)                                     
                 else:
                     HardCoded_results.append(f'name: {name}, value: {value}')
+        print(HardCoded_results)
         return HardCoded_results if HardCoded_results else None
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📌 개요
 - firebase_url 접근할 때 403 (Permission Denied) Error 출력 시 결과에 Permission Denied 추가
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 -     def _firebase_Parsing(self, content):  
          elif res.status_code == 403:
            data = "Firebase access Permission Denied"
            print(data)
현재 200과  423 코드만 처리했고 위 코드로 403코드 처리하는 로직 추가